### PR TITLE
v0.0.12 - make moa mixes configurable

### DIFF
--- a/mix-definitions/moa-coding/index.ts
+++ b/mix-definitions/moa-coding/index.ts
@@ -4,6 +4,35 @@ import readme from "./README.md"
 
 export default {
   categories: ["coding"],
+  config: {
+    aggregator: {
+      model: "gpt-4o-2024-08-06",
+      provider: "openai",
+      temperature: 0.7
+    },
+    bypassModel: {
+      model: "gpt-4o",
+      provider: "openai",
+      temperature: 0.7
+    },
+    proposers: [
+      {
+        model: "claude-3-5-sonnet-20240620",
+        provider: "anthropic",
+        temperature: 0.7
+      },
+      {
+        model: "gpt-4-turbo-2024-04-09",
+        provider: "openai",
+        temperature: 0.7
+      },
+      {
+        model: "gpt-4o-2024-08-06",
+        provider: "openai",
+        temperature: 0.7
+      }
+    ]
+  },
   cost: {
     inputCostPerUnit: 0.000006,
     outputCostPerUnit: 0.00002,

--- a/mix-definitions/types.ts
+++ b/mix-definitions/types.ts
@@ -21,6 +21,18 @@ interface FailoverRouterConfig {
 
 type RouterConfig = WeightedRouterConfig | FailoverRouterConfig
 
+interface MoaModel {
+  model: string
+  provider: string
+  temperature: number
+}
+
+interface MoaConfig {
+  bypassModel: MoaModel
+  proposers: MoaModel[]
+  aggregator: MoaModel
+}
+
 interface BaseModelMixDefinition {
   /**
    * The slug for the mix. Used as the `model` field in API requests
@@ -67,6 +79,7 @@ export interface IndexModelMixDefinition extends BaseModelMixDefinition {
 
 export interface MoaModelMixDefinition extends BaseModelMixDefinition {
   type: "moa"
+  config: MoaConfig
 }
 
 export type ModelMixDefinition = IndexModelMixDefinition | MoaModelMixDefinition

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-mixes",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Catena Labs <dev@catena.xyz>",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Right now the configuration for the composition of our MOA mix is hard-coded in our app logic. This makes it configurable on the mix definition, so that we can start introducing new MOA mixes.

For the time being, limit configuration to a single proposer layer and a single aggregator model.