### PR TITLE
v0.0.13 - remove bypass model from moa config

### DIFF
--- a/mix-definitions/moa-coding/index.ts
+++ b/mix-definitions/moa-coding/index.ts
@@ -10,11 +10,6 @@ export default {
       provider: "openai",
       temperature: 0.7
     },
-    bypassModel: {
-      model: "gpt-4o",
-      provider: "openai",
-      temperature: 0.7
-    },
     proposers: [
       {
         model: "claude-3-5-sonnet-20240620",

--- a/mix-definitions/types.ts
+++ b/mix-definitions/types.ts
@@ -28,7 +28,6 @@ interface MoaModel {
 }
 
 interface MoaConfig {
-  bypassModel: MoaModel
   proposers: MoaModel[]
   aggregator: MoaModel
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-mixes",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": "Catena Labs <dev@catena.xyz>",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
It's premature to have a configuration around moa bypass logic, this will remain hard-coded for now.