### PR TITLE
mdionis/CRO-646: Add tags to Crosshatch mixes

### DIFF
--- a/mix-definitions/crosshatch-chat-os/README.md
+++ b/mix-definitions/crosshatch-chat-os/README.md
@@ -2,9 +2,9 @@
 
 This specialized mix leverages our expertise in developing personal AI assistants like DecentAI, optimized for engaging, multi-turn conversations and roleplay scenarios. It primarily features Hermes 3, a state-of-the-art fine-tune of Llama 3.1 405B, known for its advanced long-term context retention and complex roleplaying capabilities. The mix is rounded out with Mistral AI's large-2 model, Meta's Llama 3 70B, and DeepSeek Chat, creating a robust, open-source solution for dynamic interactions. Hermes 3's training emphasizes strict adherence to system prompts and instructions, enabling highly adaptive and controlled responses in various conversational contexts.
 
-## Tags
+## Categories
 
-- 💬 **Chat**
+- 💬 **General**
 - 🌐 **Open-Source**
 
 ## Composition

--- a/mix-definitions/crosshatch-chat-os/README.md
+++ b/mix-definitions/crosshatch-chat-os/README.md
@@ -1,6 +1,11 @@
-## Crosshatch Chat
+# Crosshatch Chat
 
 This specialized mix leverages our expertise in developing personal AI assistants like DecentAI, optimized for engaging, multi-turn conversations and roleplay scenarios. It primarily features Hermes 3, a state-of-the-art fine-tune of Llama 3.1 405B, known for its advanced long-term context retention and complex roleplaying capabilities. The mix is rounded out with Mistral AI's large-2 model, Meta's Llama 3 70B, and DeepSeek Chat, creating a robust, open-source solution for dynamic interactions. Hermes 3's training emphasizes strict adherence to system prompts and instructions, enabling highly adaptive and controlled responses in various conversational contexts.
+
+## Tags
+
+- 💬 **Chat**
+- 🌐 **Open-Source**
 
 ## Composition
 

--- a/mix-definitions/crosshatch-chat-os/index.ts
+++ b/mix-definitions/crosshatch-chat-os/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["general"],
+  categories: ["general", "open-source"],
   config: {
     routes: [
       {
@@ -37,6 +37,5 @@ export default {
   name: "Crosshatch Chat",
   readme,
   slug: "crosshatch-chat-os",
-  tags: ["chat", "open-source"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/crosshatch-chat-os/index.ts
+++ b/mix-definitions/crosshatch-chat-os/index.ts
@@ -37,5 +37,6 @@ export default {
   name: "Crosshatch Chat",
   readme,
   slug: "crosshatch-chat-os",
+  tags: ["chat", "open-source"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/lmsys-coding-os/README.md
+++ b/mix-definitions/lmsys-coding-os/README.md
@@ -5,6 +5,7 @@ The best non-proprietary coding models according to the LMSys leaderboard. This 
 ## Categories
 
 - 👩🏽‍💻 **Coding**
+- 🏆 **Leaderboard**
 - 🌐 **Open-Source**
 
 ## Composition

--- a/mix-definitions/lmsys-coding-os/README.md
+++ b/mix-definitions/lmsys-coding-os/README.md
@@ -1,6 +1,11 @@
-##Top Non-Commercial Coding Models (LMSys)
+# Top Non-Commercial Coding Models (LMSys)
 
 The best non-proprietary coding models according to the LMSys leaderboard. This mix will use the top coding models ranked in the LMSys Chatbot Arena for the Coding category without any proprietary models. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
+
+## Tags
+
+- 🌐 **Open-Source**
+- 👩🏽‍💻 **Programming**
 
 ## Composition
 

--- a/mix-definitions/lmsys-coding-os/README.md
+++ b/mix-definitions/lmsys-coding-os/README.md
@@ -2,10 +2,10 @@
 
 The best non-proprietary coding models according to the LMSys leaderboard. This mix will use the top coding models ranked in the LMSys Chatbot Arena for the Coding category without any proprietary models. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
 
-## Tags
+## Categories
 
+- 👩🏽‍💻 **Coding**
 - 🌐 **Open-Source**
-- 👩🏽‍💻 **Programming**
 
 ## Composition
 

--- a/mix-definitions/lmsys-coding-os/index.ts
+++ b/mix-definitions/lmsys-coding-os/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding", "open-source"],
+  categories: ["coding", "leaderboard", "open-source"],
   config: {
     routes: [
       {

--- a/mix-definitions/lmsys-coding-os/index.ts
+++ b/mix-definitions/lmsys-coding-os/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding"],
+  categories: ["coding", "open-source"],
   config: {
     routes: [
       {
@@ -37,6 +37,5 @@ export default {
   name: "Top Non-Commercial Coding Models",
   readme,
   slug: "lmsys-coding-os",
-  tags: ["open-source", "programming"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/lmsys-coding-os/index.ts
+++ b/mix-definitions/lmsys-coding-os/index.ts
@@ -37,5 +37,6 @@ export default {
   name: "Top Non-Commercial Coding Models",
   readme,
   slug: "lmsys-coding-os",
+  tags: ["open-source", "programming"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/lmsys-coding/README.md
+++ b/mix-definitions/lmsys-coding/README.md
@@ -5,6 +5,7 @@ Don't worry about staying up to date with the latest coding model to use in your
 ## Categories
 
 - 👩🏽‍💻 **Coding**
+- 🏆 **Leaderboard**
 
 ## Composition
 

--- a/mix-definitions/lmsys-coding/README.md
+++ b/mix-definitions/lmsys-coding/README.md
@@ -2,9 +2,9 @@
 
 Don't worry about staying up to date with the latest coding model to use in your favorite IDE. This mix is based on the top coding models ranked in the LMSys Chatbot Arena for the Coding category. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
 
-## Tags
+## Categories
 
-- 👩🏽‍💻 **Programming**
+- 👩🏽‍💻 **Coding**
 
 ## Composition
 

--- a/mix-definitions/lmsys-coding/README.md
+++ b/mix-definitions/lmsys-coding/README.md
@@ -1,6 +1,10 @@
-## LMSys Coding Leaderboard Mix
+# LMSys Coding Leaderboard Mix
 
 Don't worry about staying up to date with the latest coding model to use in your favorite IDE. This mix is based on the top coding models ranked in the LMSys Chatbot Arena for the Coding category. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
+
+## Tags
+
+- 👩🏽‍💻 **Programming**
 
 ## Composition
 

--- a/mix-definitions/lmsys-coding/index.ts
+++ b/mix-definitions/lmsys-coding/index.ts
@@ -37,6 +37,5 @@ export default {
   name: "Top Coding Models",
   readme,
   slug: "lmsys-coding",
-  tags: ["programming"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/lmsys-coding/index.ts
+++ b/mix-definitions/lmsys-coding/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding"],
+  categories: ["coding", "leaderboard"],
   config: {
     routes: [
       {

--- a/mix-definitions/lmsys-coding/index.ts
+++ b/mix-definitions/lmsys-coding/index.ts
@@ -37,5 +37,6 @@ export default {
   name: "Top Coding Models",
   readme,
   slug: "lmsys-coding",
+  tags: ["programming"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/lmsys-multiturn/README.md
+++ b/mix-definitions/lmsys-multiturn/README.md
@@ -1,6 +1,11 @@
-## Top Chat Models (LMSys)
+# Top Chat Models (LMSys)
 
 Optimized for extended conversations, this mix utilizes top-performing models in multi-turn interactions. It leverages the LMSys Chatbot Arena rankings for conversations with two or more turns, ensuring high-quality responses in longer dialogues. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
+
+## Tags
+
+- 💬 **Chat**
+- 🧠 **Reasoning**
 
 ## Composition
 

--- a/mix-definitions/lmsys-multiturn/README.md
+++ b/mix-definitions/lmsys-multiturn/README.md
@@ -2,9 +2,9 @@
 
 Optimized for extended conversations, this mix utilizes top-performing models in multi-turn interactions. It leverages the LMSys Chatbot Arena rankings for conversations with two or more turns, ensuring high-quality responses in longer dialogues. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
 
-## Tags
+## Categories
 
-- 💬 **Chat**
+- 💬 **General**
 - 🧠 **Reasoning**
 
 ## Composition

--- a/mix-definitions/lmsys-multiturn/README.md
+++ b/mix-definitions/lmsys-multiturn/README.md
@@ -5,6 +5,7 @@ Optimized for extended conversations, this mix utilizes top-performing models in
 ## Categories
 
 - 💬 **General**
+- 🏆 **Leaderboard**
 - 🧠 **Reasoning**
 
 ## Composition

--- a/mix-definitions/lmsys-multiturn/index.ts
+++ b/mix-definitions/lmsys-multiturn/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["general"],
+  categories: ["general", "reasoning"],
   config: {
     routes: [
       {
@@ -41,6 +41,5 @@ export default {
   name: "Top Chat Models",
   readme,
   slug: "lmsys-multiturn",
-  tags: ["chat", "reasoning"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/lmsys-multiturn/index.ts
+++ b/mix-definitions/lmsys-multiturn/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["general", "reasoning"],
+  categories: ["general", "leaderboard", "reasoning"],
   config: {
     routes: [
       {

--- a/mix-definitions/lmsys-multiturn/index.ts
+++ b/mix-definitions/lmsys-multiturn/index.ts
@@ -41,5 +41,6 @@ export default {
   name: "Top Chat Models",
   readme,
   slug: "lmsys-multiturn",
+  tags: ["chat", "reasoning"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/lmsys-overall/README.md
+++ b/mix-definitions/lmsys-overall/README.md
@@ -1,6 +1,10 @@
-## LMSys Overall Leaderboard
+# LMSys Overall Leaderboard
 
-This mix is based on the top coding models ranked in the LMSys Chatbot Arena for the Overall category. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
+This mix is based on the top models ranked in the LMSys Chatbot Arena for the Overall category. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
+
+## Tags
+
+- 💬 **Chat**
 
 ## Composition
 

--- a/mix-definitions/lmsys-overall/README.md
+++ b/mix-definitions/lmsys-overall/README.md
@@ -5,6 +5,7 @@ This mix is based on the top models ranked in the LMSys Chatbot Arena for the Ov
 ## Categories
 
 - 💬 **General**
+- 🏆 **Leaderboard**
 
 ## Composition
 

--- a/mix-definitions/lmsys-overall/README.md
+++ b/mix-definitions/lmsys-overall/README.md
@@ -2,9 +2,9 @@
 
 This mix is based on the top models ranked in the LMSys Chatbot Arena for the Overall category. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
 
-## Tags
+## Categories
 
-- 💬 **Chat**
+- 💬 **General**
 
 ## Composition
 

--- a/mix-definitions/lmsys-overall/index.ts
+++ b/mix-definitions/lmsys-overall/index.ts
@@ -37,5 +37,6 @@ export default {
   name: "LMSys Overall Leaderboard",
   readme,
   slug: "lmsys-overall",
+  tags: ["chat"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/lmsys-overall/index.ts
+++ b/mix-definitions/lmsys-overall/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["general"],
+  categories: ["general", "leaderboard"],
   config: {
     routes: [
       {

--- a/mix-definitions/lmsys-overall/index.ts
+++ b/mix-definitions/lmsys-overall/index.ts
@@ -37,6 +37,5 @@ export default {
   name: "LMSys Overall Leaderboard",
   readme,
   slug: "lmsys-overall",
-  tags: ["chat"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/moa-coding-fast/README.md
+++ b/mix-definitions/moa-coding-fast/README.md
@@ -4,10 +4,10 @@ This is an optimized version of our Coding Mixture of Agents (MoA) designed for 
 
 With 68% classification accuracy and a bias towards the MoA when uncertain, this mix optimizes for speed without compromising on quality for challenging problems.
 
-## Tags
+## Categories
 
+- 👩🏽‍💻 **Coding**
 - 🏃🏻 **Fast**
-- 👩🏽‍💻 **Programming**
 
 ## How it Works
 

--- a/mix-definitions/moa-coding-fast/README.md
+++ b/mix-definitions/moa-coding-fast/README.md
@@ -8,6 +8,7 @@ With 68% classification accuracy and a bias towards the MoA when uncertain, this
 
 - 👩🏽‍💻 **Coding**
 - 🏃🏻 **Fast**
+- 🦾 **Mixture of Agents**
 
 ## How it Works
 

--- a/mix-definitions/moa-coding-fast/README.md
+++ b/mix-definitions/moa-coding-fast/README.md
@@ -2,6 +2,13 @@
 
 This is an optimized version of our Coding Mixture of Agents (MoA) designed for faster response times while maintaining high-quality outputs for a wide range of coding tasks.
 
+With 68% classification accuracy and a bias towards the MoA when uncertain, this mix optimizes for speed without compromising on quality for challenging problems.
+
+## Tags
+
+- 🏃🏻 **Fast**
+- 👩🏽‍💻 **Programming**
+
 ## How it Works
 
 1. **Task Classification**: Your coding request is first processed by GPT-4o-mini, which classifies the task difficulty.

--- a/mix-definitions/moa-coding-fast/index.ts
+++ b/mix-definitions/moa-coding-fast/index.ts
@@ -3,7 +3,7 @@ import type { MoaModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding"],
+  categories: ["coding", "fast"],
   config: {
     aggregator: {
       model: "gpt-4o-2024-08-06",
@@ -40,6 +40,5 @@ export default {
   name: "Fast Coding Mixture of Agents",
   readme,
   slug: "moa-coding-fast",
-  tags: ["fast", "programming"],
   type: "moa"
 } satisfies MoaModelMixDefinition

--- a/mix-definitions/moa-coding-fast/index.ts
+++ b/mix-definitions/moa-coding-fast/index.ts
@@ -40,5 +40,6 @@ export default {
   name: "Fast Coding Mixture of Agents",
   readme,
   slug: "moa-coding-fast",
+  tags: ["fast", "programming"],
   type: "moa"
 } satisfies MoaModelMixDefinition

--- a/mix-definitions/moa-coding-fast/index.ts
+++ b/mix-definitions/moa-coding-fast/index.ts
@@ -3,7 +3,7 @@ import type { MoaModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding", "fast"],
+  categories: ["coding", "fast", "mixture-of-agents"],
   config: {
     aggregator: {
       model: "gpt-4o-2024-08-06",

--- a/mix-definitions/moa-coding-os/README.md
+++ b/mix-definitions/moa-coding-os/README.md
@@ -4,6 +4,12 @@ This is a synthesis mix that uses a mixture-of-agents architecture to provide hi
 
 To learn more about mixture of agents, check out our Github repo [here](https://github.com/catena-labs/moa-llm).
 
+## Tags
+
+- 🌐 **Open-Source**
+- 👩🏽‍💻 **Programming**
+- 🧠 **Reasoning**
+
 ## Quality
 
 According to our evaluations, this mix outperforms several leading commercial models on the Bigcodebench Instruct Hard dataset, a benchmark aimed at measuring the performance of LLMs for difficult coding tasks.

--- a/mix-definitions/moa-coding-os/README.md
+++ b/mix-definitions/moa-coding-os/README.md
@@ -4,10 +4,10 @@ This is a synthesis mix that uses a mixture-of-agents architecture to provide hi
 
 To learn more about mixture of agents, check out our Github repo [here](https://github.com/catena-labs/moa-llm).
 
-## Tags
+## Categories
 
+- 👩🏽‍💻 **Coding**
 - 🌐 **Open-Source**
-- 👩🏽‍💻 **Programming**
 - 🧠 **Reasoning**
 
 ## Quality

--- a/mix-definitions/moa-coding-os/README.md
+++ b/mix-definitions/moa-coding-os/README.md
@@ -7,6 +7,7 @@ To learn more about mixture of agents, check out our Github repo [here](https://
 ## Categories
 
 - 👩🏽‍💻 **Coding**
+- 🦾 **Mixture of Agents**
 - 🌐 **Open-Source**
 - 🧠 **Reasoning**
 

--- a/mix-definitions/moa-coding-os/index.ts
+++ b/mix-definitions/moa-coding-os/index.ts
@@ -3,7 +3,7 @@ import type { MoaModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding", "open-source", "reasoning"],
+  categories: ["coding", "mixture-of-agents", "open-source", "reasoning"],
   config: {
     aggregator: {
       model: "meta-llama/Meta-Llama-3.1-405B-Instruct",

--- a/mix-definitions/moa-coding-os/index.ts
+++ b/mix-definitions/moa-coding-os/index.ts
@@ -3,7 +3,7 @@ import type { MoaModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding"],
+  categories: ["coding", "open-source", "reasoning"],
   config: {
     aggregator: {
       model: "meta-llama/Meta-Llama-3.1-405B-Instruct",
@@ -35,6 +35,5 @@ export default {
   name: "Open-Source Coding Mixture of Agents",
   readme,
   slug: "moa-coding-os",
-  tags: ["open-source", "programming", "reasoning"],
   type: "moa"
 } satisfies MoaModelMixDefinition

--- a/mix-definitions/moa-coding-os/index.ts
+++ b/mix-definitions/moa-coding-os/index.ts
@@ -35,5 +35,6 @@ export default {
   name: "Open-Source Coding Mixture of Agents",
   readme,
   slug: "moa-coding-os",
+  tags: ["open-source", "programming", "reasoning"],
   type: "moa"
 } satisfies MoaModelMixDefinition

--- a/mix-definitions/moa-coding/README.md
+++ b/mix-definitions/moa-coding/README.md
@@ -1,8 +1,13 @@
-## Coding Mixture of Agents
+# Coding Mixture of Agents
 
 This is a synthesis mix that uses a mixture-of-agents architecture to give you the highest quality answers. Your request is sent to two "proposer" models (Claude 3.5 Sonnet and GPT-4 Turbo). The responses from these models are passed to an "aggregation" model (GPT-4o) which synthesizes the answers, corrects issues, and returns code.
 
 To learn more about mixture of agents, check out our Github repo [here](https://github.com/catena-labs/moa).
+
+## Tags
+
+- 👩🏽‍💻 **Programming**
+- 🧠 **Reasoning**
 
 ## Quality
 

--- a/mix-definitions/moa-coding/README.md
+++ b/mix-definitions/moa-coding/README.md
@@ -4,9 +4,9 @@ This is a synthesis mix that uses a mixture-of-agents architecture to give you t
 
 To learn more about mixture of agents, check out our Github repo [here](https://github.com/catena-labs/moa).
 
-## Tags
+## Categories
 
-- 👩🏽‍💻 **Programming**
+- 👩🏽‍💻 **Coding**
 - 🧠 **Reasoning**
 
 ## Quality

--- a/mix-definitions/moa-coding/README.md
+++ b/mix-definitions/moa-coding/README.md
@@ -7,6 +7,7 @@ To learn more about mixture of agents, check out our Github repo [here](https://
 ## Categories
 
 - 👩🏽‍💻 **Coding**
+- 🦾 **Mixture of Agents**
 - 🧠 **Reasoning**
 
 ## Quality

--- a/mix-definitions/moa-coding/index.ts
+++ b/mix-definitions/moa-coding/index.ts
@@ -3,7 +3,7 @@ import type { MoaModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding", "reasoning"],
+  categories: ["coding", "mixture-of-agents", "reasoning"],
   config: {
     aggregator: {
       model: "gpt-4o-2024-08-06",

--- a/mix-definitions/moa-coding/index.ts
+++ b/mix-definitions/moa-coding/index.ts
@@ -3,7 +3,7 @@ import type { MoaModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["coding"],
+  categories: ["coding", "reasoning"],
   config: {
     aggregator: {
       model: "gpt-4o-2024-08-06",
@@ -40,6 +40,5 @@ export default {
   name: "Coding Mixture of Agents",
   readme,
   slug: "moa-coding",
-  tags: ["programming", "reasoning"],
   type: "moa"
 } satisfies MoaModelMixDefinition

--- a/mix-definitions/moa-coding/index.ts
+++ b/mix-definitions/moa-coding/index.ts
@@ -40,5 +40,6 @@ export default {
   name: "Coding Mixture of Agents",
   readme,
   slug: "moa-coding",
+  tags: ["programming", "reasoning"],
   type: "moa"
 } satisfies MoaModelMixDefinition

--- a/mix-definitions/seal-spanish/README.md
+++ b/mix-definitions/seal-spanish/README.md
@@ -1,10 +1,14 @@
-## Spanish Mix (Scale.ai Leaderboard)
+# Spanish Mix (Scale.ai Leaderboard)
 
 This mix is based on the top models ranked for Spanish by Scale.ai's SEAL leaderboard. The weight is a function of the Elo score.
 
 The evaluation process involves assessing model responses across three main dimensions: honesty (understanding and consistency), accuracy (correctness of claims), and helpfulness (instruction following and writing quality). Models are paired against each other and evaluated on these criteria, with a focus on instruction following abilities.
 
 The top-performing models in the Spanish leaderboard are GPT-4o in first place, followed by Gemini 1.5 Pro (May 2024) in second, and GPT-4 Turbo Preview in third.
+
+## Tags
+
+- 🗣️ **Translation**
 
 ## Composition
 

--- a/mix-definitions/seal-spanish/README.md
+++ b/mix-definitions/seal-spanish/README.md
@@ -9,7 +9,7 @@ The top-performing models in the Spanish leaderboard are GPT-4o in first place, 
 ## Categories
 
 - 💬 **General**
-- 🗣️ **Translation**
+- 🗣️ **Multilingual**
 
 ## Composition
 

--- a/mix-definitions/seal-spanish/README.md
+++ b/mix-definitions/seal-spanish/README.md
@@ -6,8 +6,9 @@ The evaluation process involves assessing model responses across three main dime
 
 The top-performing models in the Spanish leaderboard are GPT-4o in first place, followed by Gemini 1.5 Pro (May 2024) in second, and GPT-4 Turbo Preview in third.
 
-## Tags
+## Categories
 
+- 💬 **General**
 - 🗣️ **Translation**
 
 ## Composition

--- a/mix-definitions/seal-spanish/index.ts
+++ b/mix-definitions/seal-spanish/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["general", "translation"],
+  categories: ["general", "multilingual"],
   config: {
     routes: [
       {

--- a/mix-definitions/seal-spanish/index.ts
+++ b/mix-definitions/seal-spanish/index.ts
@@ -33,5 +33,6 @@ export default {
   name: "Spanish Mix (Scale.ai Leaderboard)",
   readme,
   slug: "seal-spanish",
+  tags: ["translation"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/seal-spanish/index.ts
+++ b/mix-definitions/seal-spanish/index.ts
@@ -3,7 +3,7 @@ import type { IndexModelMixDefinition } from "../types"
 import readme from "./README.md"
 
 export default {
-  categories: ["general"],
+  categories: ["general", "translation"],
   config: {
     routes: [
       {
@@ -33,6 +33,5 @@ export default {
   name: "Spanish Mix (Scale.ai Leaderboard)",
   readme,
   slug: "seal-spanish",
-  tags: ["translation"],
   type: "index"
 } satisfies IndexModelMixDefinition

--- a/mix-definitions/types.ts
+++ b/mix-definitions/types.ts
@@ -1,5 +1,13 @@
 type Category = "general" | "coding"
 
+type Tag =
+  | "chat"
+  | "fast"
+  | "open-source"
+  | "programming"
+  | "reasoning"
+  | "translation"
+
 interface BaseRoute {
   model: string
   provider?: string
@@ -69,6 +77,10 @@ interface BaseModelMixDefinition {
     outputCostPerUnit: number
     unit: "token"
   }
+  /**
+   * Tags for identifying mix characteristics
+   */
+  tags?: Tag[]
 }
 
 export interface IndexModelMixDefinition extends BaseModelMixDefinition {

--- a/mix-definitions/types.ts
+++ b/mix-definitions/types.ts
@@ -1,10 +1,8 @@
-type Category = "general" | "coding"
-
-type Tag =
-  | "chat"
+type Category =
+  | "coding"
   | "fast"
+  | "general"
   | "open-source"
-  | "programming"
   | "reasoning"
   | "translation"
 
@@ -77,10 +75,6 @@ interface BaseModelMixDefinition {
     outputCostPerUnit: number
     unit: "token"
   }
-  /**
-   * Tags for identifying mix characteristics
-   */
-  tags?: Tag[]
 }
 
 export interface IndexModelMixDefinition extends BaseModelMixDefinition {

--- a/mix-definitions/types.ts
+++ b/mix-definitions/types.ts
@@ -2,9 +2,11 @@ export type Category =
   | "coding"
   | "fast"
   | "general"
+  | "leaderboard"
+  | "mixture-of-agents"
+  | "multilingual"
   | "open-source"
   | "reasoning"
-  | "translation"
 
 interface BaseRoute {
   model: string

--- a/mix-definitions/types.ts
+++ b/mix-definitions/types.ts
@@ -1,4 +1,4 @@
-type Category =
+export type Category =
   | "coding"
   | "fast"
   | "general"


### PR DESCRIPTION
## [mdionis/CRO-646: Add tags to Crosshatch mixes](https://linear.app/catena-labs/issue/CRO-646/add-tags-to-crosshatch-mixes)

These changes leverage the existing `categories` array of type `Category` to support "tags". `Category` can now be one of:

  | "coding"
  | "fast"
  | "general"
  | "leaderboard"
  | "mixture-of-agents"
  | "multilingual"
  | "open-source"
  | "reasoning"
  
Relevant categories were applied to each mix and each mix README was updated to establish consistent formatting and to list categories.

These changes were tested locally to ensure they work well in the monorepo where they will be utilized. 👍🏻 