### PR TITLE
Update prepublishOnly script to properly call build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
-    "prepublishOnly": "bun check && bun build",
+    "prepublishOnly": "bun check && bun run build",
     "type-check": "tsc --noEmit --pretty"
   },
   "devDependencies": {


### PR DESCRIPTION
This can be safely tested by running: `bunx npm@latest publish --dry-run`