### PR TITLE
Updated mix composition + prices

### DIFF
--- a/mix-definitions/lmsys-chinese/README.md
+++ b/mix-definitions/lmsys-chinese/README.md
@@ -2,10 +2,20 @@
 
 This mix picks the highest-ranked model for Chinese prompts, based on LMSys Chinese Leaderboard.
 
-| Model                        | Weight % |
-| ---------------------------- | -------- |
-| "chatgpt-4o-latest-20240903" | 36.52%   |
-| "gemini-1.5-pro-exp-0827"    | 23.04%   |
-| "o1-preview"                 | 21.26%   |
-| "chatgpt-4o-latest-20240808" | 15.85%   |
-| "o1-mini"                    | 3.32%    |
+## Categories
+
+- 💬 **General**
+- 🏆 **Leaderboard**
+- 🗣️ **Multilingual**
+
+## Composition
+
+This mix produces responses from the following models:
+
+| Model                       | Weight % |
+| --------------------------- | -------- |
+| "chatgpt-4o-latest"         | 49.36%   |
+| "gemini-1.5-pro-exp-0827"   | 20.28%   |
+| "gemini-1.5-pro-002"        | 15.93%   |
+| "gemini-1.5-pro-exp-0801"   | 11.29%   |
+| "gemini-1.5-flash-exp-0827" | 3.13%    |

--- a/mix-definitions/lmsys-chinese/index.ts
+++ b/mix-definitions/lmsys-chinese/index.ts
@@ -7,31 +7,31 @@ export default {
   config: {
     routes: [
       {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.3652
+        model: "chatgpt-4o-latest",
+        weight: 0.4936
       },
       {
         model: "gemini-1.5-pro-exp-0827",
-        weight: 0.2304
+        weight: 0.2028
       },
       {
-        model: "o1-preview",
-        weight: 0.2126
+        model: "gemini-1.5-pro-002",
+        weight: 0.1593
       },
       {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.1585
+        model: "gemini-1.5-pro-exp-0801",
+        weight: 0.1129
       },
       {
-        model: "o1-mini",
-        weight: 0.0332
+        model: "gemini-1.5-flash-exp-0827",
+        weight: 0.0313
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000068487,
-    outputCostPerUnit: 0.0000239013,
+    inputCostPerUnit: 0.0000042158,
+    outputCostPerUnit: 0.0000126493,
     unit: "token"
   },
   createdAt: new Date("2024-10-10T13:00:00-04:00"),

--- a/mix-definitions/lmsys-coding/README.md
+++ b/mix-definitions/lmsys-coding/README.md
@@ -2,6 +2,8 @@
 
 Don't worry about staying up to date with the latest coding model to use in your favorite IDE. This mix is based on the top coding models ranked in the LMSys Chatbot Arena for the Coding category. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
 
+Note: `o1-mini` and `o1-preview` are not included in this mix because they do not support system prompts and other parameters.
+
 ## Categories
 
 - 👩🏽‍💻 **Coding**
@@ -11,13 +13,15 @@ Don't worry about staying up to date with the latest coding model to use in your
 
 This mix produces responses from the following models:
 
-| Model                        | Weight % |
-| ---------------------------- | -------- |
-| "o1-mini"                    | 35.73%   |
-| "o1-preview"                 | 25.43%   |
-| "chatgpt-4o-latest-20240903" | 19.76%   |
-| "chatgpt-4o-latest-20240808" | 15.83%   |
-| "claude-3-5-sonnet-20240620" | 3.25%    |
+| Model                                     | Weight % |
+| ----------------------------------------- | -------- |
+| "chatgpt-4o-latest"                       | 53.48%   |
+| "gpt-4o-2024-05-13"                       | 15.76%   |
+| "claude-3-5-sonnet-20240620"              | 14.33%   |
+| "gemini-1.5-pro-exp-0827"                 | 8.67%    |
+| "meta-llama/Meta-Llama-3.1-405B-Instruct" | 5.03%    |
+| "gemini-1.5-pro-002"                      | 2.73%    |
 
 Update Frequency: Based on LMSys (every few weeks)
+
 Source: <https://lmarena.ai/>

--- a/mix-definitions/lmsys-coding/index.ts
+++ b/mix-definitions/lmsys-coding/index.ts
@@ -7,31 +7,35 @@ export default {
   config: {
     routes: [
       {
-        model: "o1-mini",
-        weight: 0.3573
+        model: "chatgpt-4o-latest",
+        weight: 0.5348
       },
       {
-        model: "o1-preview",
-        weight: 0.2543
-      },
-      {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.1976
-      },
-      {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.1583
+        model: "gpt-4o-2024-05-13",
+        weight: 0.1576
       },
       {
         model: "claude-3-5-sonnet-20240620",
-        weight: 0.0325
+        weight: 0.1433
+      },
+      {
+        model: "gemini-1.5-pro-exp-0827",
+        weight: 0.0867
+      },
+      {
+        model: "meta-llama/Meta-Llama-3.1-405B-Instruct",
+        weight: 0.0503
+      },
+      {
+        model: "gemini-1.5-pro-002",
+        weight: 0.0273
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000068985,
-    outputCostPerUnit: 0.0000258785,
+    inputCostPerUnit: 0.0000045563,
+    outputCostPerUnit: 0.0000141864,
     unit: "token"
   },
   createdAt: new Date("2024-08-13T13:00:00-04:00"), // August 13, 2024 1pm Eastern

--- a/mix-definitions/lmsys-french/README.md
+++ b/mix-definitions/lmsys-french/README.md
@@ -13,10 +13,10 @@ This mix picks the highest-ranked model for French prompts, based on LMSys Frenc
 
 This mix produces responses from the following models:
 
-| Model                        | Weight % |
-| ---------------------------- | -------- |
-| "gemini-1.5-pro-exp-0801"    | 39.77%   |
-| "chatgpt-4o-latest-20240903" | 28.61%   |
-| "chatgpt-4o-latest-20240808" | 21.96%   |
-| "gemini-1.5-pro-exp-0827"    | 6.04%    |
-| "o1-preview"                 | 3.62%    |
+| Model                     | Weight % |
+| ------------------------- | -------- |
+| "chatgpt-4o-latest"       | 44.01%   |
+| "gemini-1.5-pro-exp-0801" | 22.81%   |
+| "gemini-1.5-pro-exp-0827" | 20.25%   |
+| "gpt-4o-2024-05-13"       | 10.65%   |
+| "gemini-pro"              | 2.28%    |

--- a/mix-definitions/lmsys-french/index.ts
+++ b/mix-definitions/lmsys-french/index.ts
@@ -7,31 +7,31 @@ export default {
   config: {
     routes: [
       {
+        model: "chatgpt-4o-latest",
+        weight: 0.4401
+      },
+      {
         model: "gemini-1.5-pro-exp-0801",
-        weight: 0.3977
-      },
-      {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.2861
-      },
-      {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.2196
+        weight: 0.2281
       },
       {
         model: "gemini-1.5-pro-exp-0827",
-        weight: 0.0604
+        weight: 0.2025
       },
       {
-        model: "o1-preview",
-        weight: 0.0362
+        model: "gpt-4o-2024-05-13",
+        weight: 0.1065
+      },
+      {
+        model: "gemini-pro",
+        weight: 0.0228
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000047678,
-    outputCostPerUnit: 0.0000148567,
+    inputCostPerUnit: 0.0000043366,
+    outputCostPerUnit: 0.0000130098,
     unit: "token"
   },
   createdAt: new Date("2024-10-10T13:00:00-04:00"),

--- a/mix-definitions/lmsys-german/README.md
+++ b/mix-definitions/lmsys-german/README.md
@@ -12,10 +12,11 @@ This mix picks the highest-ranked model for German prompts, based on LMSys Germa
 
 This mix produces responses from the following models:
 
-| Model                        | Weight % |
-| ---------------------------- | -------- |
-| "chatgpt-4o-latest-20240808" | 29.14%   |
-| "o1-preview"                 | 26.81%   |
-| "chatgpt-4o-latest-20240903" | 25.15%   |
-| "gemini-1.5-pro-exp-0827"    | 16.24%   |
-| "o1-mini"                    | 2.65%    |
+| Model                     | Weight % |
+| ------------------------- | -------- |
+| "chatgpt-4o-latest"       | 52.90%   |
+| "gemini-1.5-pro-exp-0827" | 18.33%   |
+| "gemini-1.5-pro-exp-0801" | 11.18%   |
+| "gpt-4o-2024-05-13"       | 10.70%   |
+| "gemini-1.5-pro-002"      | 4.48%    |
+| "gpt-4o-mini"             | 2.41%    |

--- a/mix-definitions/lmsys-german/index.ts
+++ b/mix-definitions/lmsys-german/index.ts
@@ -7,31 +7,35 @@ export default {
   config: {
     routes: [
       {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.2914
-      },
-      {
-        model: "o1-preview",
-        weight: 0.2681
-      },
-      {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.2515
+        model: "chatgpt-4o-latest",
+        weight: 0.529
       },
       {
         model: "gemini-1.5-pro-exp-0827",
-        weight: 0.1624
+        weight: 0.1833
       },
       {
-        model: "o1-mini",
-        weight: 0.0265
+        model: "gemini-1.5-pro-exp-0801",
+        weight: 0.1118
+      },
+      {
+        model: "gpt-4o-2024-05-13",
+        weight: 0.107
+      },
+      {
+        model: "gemini-1.5-pro-002",
+        weight: 0.0448
+      },
+      {
+        model: "gpt-4o-mini",
+        weight: 0.0241
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000075322,
-    outputCostPerUnit: 0.0000267798,
+    inputCostPerUnit: 0.0000044608,
+    outputCostPerUnit: 0.000013386,
     unit: "token"
   },
   createdAt: new Date("2024-10-10T13:00:00-04:00"),

--- a/mix-definitions/lmsys-japanese/README.md
+++ b/mix-definitions/lmsys-japanese/README.md
@@ -12,10 +12,10 @@ This mix picks the highest-ranked model for Japanese prompts, based on LMSys Jap
 
 This mix produces responses from the following models:
 
-| Model                        | Weight % |
-| ---------------------------- | -------- |
-| "chatgpt-4o-latest-20240903" | 44.06%   |
-| "o1-preview"                 | 26.16%   |
-| "gemini-1.5-pro-exp-0801"    | 14.56%   |
-| "gemini-1.5-pro-exp-0827"    | 11.21%   |
-| "chatgpt-4o-latest-20240808" | 4.01%    |
+| Model                     | Weight % |
+| ------------------------- | -------- |
+| "chatgpt-4o-latest"       | 50.28%   |
+| "gemini-1.5-pro-exp-0801" | 18.48%   |
+| "gemini-1.5-pro-exp-0827" | 16.95%   |
+| "gemini-1.5-pro-002"      | 10.90%   |
+| "gpt-4o-2024-05-13"       | 3.39%    |

--- a/mix-definitions/lmsys-japanese/index.ts
+++ b/mix-definitions/lmsys-japanese/index.ts
@@ -7,31 +7,31 @@ export default {
   config: {
     routes: [
       {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.4406
-      },
-      {
-        model: "o1-preview",
-        weight: 0.2616
+        model: "chatgpt-4o-latest",
+        weight: 0.5028
       },
       {
         model: "gemini-1.5-pro-exp-0801",
-        weight: 0.1456
+        weight: 0.1848
       },
       {
         model: "gemini-1.5-pro-exp-0827",
-        weight: 0.1121
+        weight: 0.1695
       },
       {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.0401
+        model: "gemini-1.5-pro-002",
+        weight: 0.109
+      },
+      {
+        model: "gpt-4o-2024-05-13",
+        weight: 0.0339
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000073738,
-    outputCostPerUnit: 0.0000261236,
+    inputCostPerUnit: 0.0000043911,
+    outputCostPerUnit: 0.0000131732,
     unit: "token"
   },
   createdAt: new Date("2024-10-10T13:00:00-04:00"),

--- a/mix-definitions/lmsys-korean/README.md
+++ b/mix-definitions/lmsys-korean/README.md
@@ -12,10 +12,9 @@ This mix picks the highest-ranked model for Korean prompts, based on LMSys Korea
 
 This mix produces responses from the following models:
 
-| Model                        | Weight % |
-| ---------------------------- | -------- |
-| "chatgpt-4o-latest-20240903" | 44.06%   |
-| "o1-preview"                 | 26.16%   |
-| "gemini-1.5-pro-exp-0801"    | 14.56%   |
-| "gemini-1.5-pro-exp-0827"    | 11.21%   |
-| "chatgpt-4o-latest-20240808" | 4.01%    |
+| Model                     | Weight % |
+| ------------------------- | -------- |
+| "gemini-1.5-pro-002"      | 72.01%   |
+| "chatgpt-4o-latest"       | 16.92%   |
+| "gemini-1.5-pro-exp-0827" | 7.64%    |
+| "gemini-1.5-pro-exp-0801" | 3.42%    |

--- a/mix-definitions/lmsys-korean/index.ts
+++ b/mix-definitions/lmsys-korean/index.ts
@@ -7,31 +7,27 @@ export default {
   config: {
     routes: [
       {
-        model: "gemini-1.5-pro-api-0409-preview",
-        weight: 0.4244
+        model: "gemini-1.5-pro-002",
+        weight: 0.7202
       },
       {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.3218
-      },
-      {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.1708
+        model: "chatgpt-4o-latest",
+        weight: 0.1692
       },
       {
         model: "gemini-1.5-pro-exp-0827",
-        weight: 0.0444
+        weight: 0.0764
       },
       {
         model: "gemini-1.5-pro-exp-0801",
-        weight: 0.0386
+        weight: 0.0342
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000043237,
-    outputCostPerUnit: 0.0000129711,
+    inputCostPerUnit: 0.0000038289,
+    outputCostPerUnit: 0.0000114867,
     unit: "token"
   },
   createdAt: new Date("2024-10-10T13:00:00-04:00"),

--- a/mix-definitions/lmsys-multiturn/README.md
+++ b/mix-definitions/lmsys-multiturn/README.md
@@ -14,11 +14,12 @@ This mix produces responses from the following models:
 
 | Model                        | Weight % |
 | ---------------------------- | -------- |
-| "o1-preview"                 | 33.33%   |
-| "chatgpt-4o-latest-20240903" | 32.69%   |
-| "chatgpt-4o-latest-20240808" | 22.78%   |
-| "claude-3-5-sonnet-20240620" | 8.17%    |
-| "o1-mini"                    | 3.03%    |
+| "chatgpt-4o-latest"          | 53.92%   |
+| "gpt-4o-2024-05-13"          | 13.39%   |
+| "claude-3-5-sonnet-20240620" | 12.67%   |
+| "gemini-1.5-pro-exp-0827"    | 9.09%    |
+| "gemini-1.5-pro-exp-0801"    | 8.13%    |
+| "gemini-1.5-pro-002"         | 2.80%    |
 
 Update Frequency: Based on LMSys
 Source: <https://lmarena.ai/>

--- a/mix-definitions/lmsys-multiturn/index.ts
+++ b/mix-definitions/lmsys-multiturn/index.ts
@@ -7,31 +7,35 @@ export default {
   config: {
     routes: [
       {
-        model: "o1-preview",
-        weight: 0.3333
+        model: "chatgpt-4o-latest",
+        weight: 0.5392
       },
       {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.3269
-      },
-      {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.2278
+        model: "gpt-4o-2024-05-13",
+        weight: 0.1339
       },
       {
         model: "claude-3-5-sonnet-20240620",
-        weight: 0.0817
+        weight: 0.1267
       },
       {
-        model: "o1-mini",
-        weight: 0.0303
+        model: "gemini-1.5-pro-exp-0827",
+        weight: 0.0909
+      },
+      {
+        model: "gemini-1.5-pro-exp-0801",
+        weight: 0.0813
+      },
+      {
+        model: "gemini-1.5-pro-002",
+        weight: 0.028
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000082713,
-    outputCostPerUnit: 0.000030506,
+    inputCostPerUnit: 0.0000045352,
+    outputCostPerUnit: 0.0000143811,
     unit: "token"
   },
   createdAt: new Date("2024-09-09T13:00:00-04:00"),

--- a/mix-definitions/lmsys-overall/README.md
+++ b/mix-definitions/lmsys-overall/README.md
@@ -2,6 +2,8 @@
 
 This mix is based on the top models ranked in the LMSys Chatbot Arena for the Overall category. The weight is a function of the Elo score adjusted for number of votes and variance. Models with more consistently high votes will be weighed more heavily.
 
+Note: `o1-mini` and `o1-preview` are not included in this mix because they do not support system prompts and other parameters.
+
 ## Categories
 
 - 💬 **General**
@@ -11,13 +13,14 @@ This mix is based on the top models ranked in the LMSys Chatbot Arena for the Ov
 
 This mix produces responses from the following models:
 
-| Model                        | Weight % |
-| ---------------------------- | -------- |
-| "chatgpt-4o-latest-20240903" | 37.69%   |
-| "o1-preview"                 | 29.63%   |
-| "chatgpt-4o-latest-20240808" | 23.20%   |
-| "o1-mini"                    | 6.06%    |
-| "gemini-1.5-pro-exp-0827"    | 3.43%    |
+| Model                     | Weight % |
+| ------------------------- | -------- |
+| "chatgpt-4o-latest"       | 50.26%   |
+| "gemini-1.5-pro-exp-0827" | 13.56%   |
+| "gpt-4o-2024-05-13"       | 12.93%   |
+| "gemini-1.5-pro-exp-0801" | 11.56%   |
+| "gemini-1.5-pro-002"      | 9.03%    |
+| "gpt-4o-mini"             | 2.66%    |
 
 Update Frequency: Based on LMSys (every few weeks)
 Source: <https://lmarena.ai/>

--- a/mix-definitions/lmsys-overall/index.ts
+++ b/mix-definitions/lmsys-overall/index.ts
@@ -7,31 +7,35 @@ export default {
   config: {
     routes: [
       {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.3769
-      },
-      {
-        model: "o1-preview",
-        weight: 0.2963
-      },
-      {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.232
-      },
-      {
-        model: "o1-mini",
-        weight: 0.0606
+        model: "chatgpt-4o-latest",
+        weight: 0.5027
       },
       {
         model: "gemini-1.5-pro-exp-0827",
-        weight: 0.0343
+        weight: 0.1356
+      },
+      {
+        model: "gpt-4o-2024-05-13",
+        weight: 0.1293
+      },
+      {
+        model: "gemini-1.5-pro-exp-0801",
+        weight: 0.1156
+      },
+      {
+        model: "gemini-1.5-pro-002",
+        weight: 0.0903
+      },
+      {
+        model: "gpt-4o-mini",
+        weight: 0.0266
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000079457,
-    outputCostPerUnit: 0.0000285554,
+    inputCostPerUnit: 0.000004446,
+    outputCostPerUnit: 0.0000133421,
     unit: "token"
   },
   createdAt: new Date("2024-09-09T13:00:00-04:00"), // August 13, 2024 1pm Eastern

--- a/mix-definitions/lmsys-russian/README.md
+++ b/mix-definitions/lmsys-russian/README.md
@@ -10,10 +10,11 @@ This mix picks the highest-ranked model for Russian prompts, based on LMSys Russ
 
 ## Composition
 
-| Model                        | Weight % |
-| ---------------------------- | -------- |
-| "chatgpt-4o-latest-20240903" | 29.47%   |
-| "gemini-1.5-pro-exp-0827"    | 25.20%   |
-| "chatgpt-4o-latest-20240808" | 23.18%   |
-| "gemini-1.5-pro-exp-0801"    | 19.47%   |
-| "o1-preview"                 | 2.68%    |
+| Model                       | Weight % |
+| --------------------------- | -------- |
+| "chatgpt-4o-latest"         | 41.59%   |
+| "gemini-1.5-pro-exp-0827"   | 20.15%   |
+| "gemini-1.5-pro-exp-0801"   | 16.25%   |
+| "gemini-1.5-pro-002"        | 12.52%   |
+| "claude-3-opus-20240229"    | 7.31%    |
+| "gemini-1.5-flash-exp-0827" | 2.19%    |

--- a/mix-definitions/lmsys-russian/index.ts
+++ b/mix-definitions/lmsys-russian/index.ts
@@ -7,31 +7,35 @@ export default {
   config: {
     routes: [
       {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.2947
+        model: "chatgpt-4o-latest",
+        weight: 0.4159
       },
       {
         model: "gemini-1.5-pro-exp-0827",
-        weight: 0.252
-      },
-      {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.2318
+        weight: 0.2015
       },
       {
         model: "gemini-1.5-pro-exp-0801",
-        weight: 0.1947
+        weight: 0.1625
       },
       {
-        model: "o1-preview",
-        weight: 0.0268
+        model: "gemini-1.5-pro-002",
+        weight: 0.1252
+      },
+      {
+        model: "claude-3-opus-20240229",
+        weight: 0.0731
+      },
+      {
+        model: "gemini-1.5-flash-exp-0827",
+        weight: 0.0219
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000046897,
-    outputCostPerUnit: 0.0000144789,
+    inputCostPerUnit: 0.0000049875,
+    outputCostPerUnit: 0.0000172012,
     unit: "token"
   },
   createdAt: new Date("2024-10-10T13:00:00-04:00"),

--- a/mix-definitions/lmsys-spanish/README.md
+++ b/mix-definitions/lmsys-spanish/README.md
@@ -14,8 +14,9 @@ This mix produces responses from the following models:
 
 | Model                        | Weight % |
 | ---------------------------- | -------- |
-| "chatgpt-4o-latest-20240903" | 39.30%   |
-| "o1-preview"                 | 31.45%   |
-| "o1-mini"                    | 17.75%   |
-| "chatgpt-4o-latest-20240808" | 7.92%    |
-| "gemini-1.5-pro-exp-0827"    | 3.57%    |
+| "chatgpt-4o-latest"          | 50.46%   |
+| "gemini-1.5-pro-exp-0827"    | 18.63%   |
+| "gemini-1.5-pro-exp-0801"    | 11.25%   |
+| "claude-3-5-sonnet-20240620" | 10.37%   |
+| "gemini-1.5-pro-002"         | 6.63%    |
+| "gpt-4o-mini"                | 2.66%    |

--- a/mix-definitions/lmsys-spanish/index.ts
+++ b/mix-definitions/lmsys-spanish/index.ts
@@ -7,31 +7,35 @@ export default {
   config: {
     routes: [
       {
-        model: "chatgpt-4o-latest-20240903",
-        weight: 0.393
-      },
-      {
-        model: "o1-preview",
-        weight: 0.3145
-      },
-      {
-        model: "o1-mini",
-        weight: 0.1775
-      },
-      {
-        model: "chatgpt-4o-latest-20240808",
-        weight: 0.0792
+        model: "chatgpt-4o-latest",
+        weight: 0.5046
       },
       {
         model: "gemini-1.5-pro-exp-0827",
-        weight: 0.0357
+        weight: 0.1863
+      },
+      {
+        model: "gemini-1.5-pro-exp-0801",
+        weight: 0.1125
+      },
+      {
+        model: "claude-3-5-sonnet-20240620",
+        weight: 0.1037
+      },
+      {
+        model: "gemini-1.5-pro-002",
+        weight: 0.0663
+      },
+      {
+        model: "gpt-4o-mini",
+        weight: 0.0266
       }
     ],
     strategy: "weighted"
   },
   cost: {
-    inputCostPerUnit: 0.0000078913,
-    outputCostPerUnit: 0.0000078913,
+    inputCostPerUnit: 0.0000041982,
+    outputCostPerUnit: 0.0000132335,
     unit: "token"
   },
   createdAt: new Date("2024-10-10T13:00:00-04:00"),


### PR DESCRIPTION
- I modified the logic to generate mixes to remove o1-preview and o1-mini from the candidate list
- I extended the original candidate list to include more models, this means the resulting mixes should have more models
- Removing o1-preview reduces the prices signficantly